### PR TITLE
Add surface_net_downward_shortwave_flux

### DIFF
--- a/python/cdmGribReaderConfig.xml
+++ b/python/cdmGribReaderConfig.xml
@@ -724,21 +724,10 @@
       <attribute name="units" value="m/s" type="string"/>
       <attribute name="standard_name" value="wind_speed" type="string"/>
     </parameter>
-    <parameter name="137Cesium_concentration" type="float">
-        <grib1 indicatorOfParameter="200" gribTablesVersionNo="133" identificationOfOriginatingGeneratingCentre="54">
-            <extraKey name="isotopeIdentificationNumber" value="169"/>
-        </grib1>
-        <!--  <attribute name="standard_name" value="geopotential_height" type="string" /> -->
-        <attribute name="units" value="Bq*h/m3" type="string" />
+    <parameter name="ASOB_S" type="float">
+        <grib2 discipline="0" parameterCategory="4" parameterNumber="9" typeOfLevel="1"/>
+        <attribute name="standard_name" value="average_of_surface_net_downward_shortwave_flux_wrt_time" type="string" />
+        <attribute name="units" value="W/m^2" type="string" />
     </parameter>
-    <parameter name="133Xenon_concentration" type="float">
-        <grib1 indicatorOfParameter="200" gribTablesVersionNo="133" identificationOfOriginatingGeneratingCentre="54">
-          <extraKey name="isotopeIdentificationNumber" value="158"/>
-        </grib1>
-        <!--  <attribute name="standard_name" value="geopotential_height" type="string" /> -->
-        <attribute name="units" value="Bq*h/m3" type="string" />
-    </parameter>
-
-
 </variables>
 </cdmGribReaderConfig>

--- a/python/cdmGribReaderConfig.xml
+++ b/python/cdmGribReaderConfig.xml
@@ -25,8 +25,6 @@
 <time id="time" name="time" type="double">
     <attribute name="long_name" value="time" type="string" />
     <attribute name="standard_name" value="time" type="string" />
-<!-- adapt the time-unit as needed, i.e. -->
-<!-- <attribute name="units" value="hours since 2007-05-16 00:00:00 +00:00" type="string" /> -->
     <attribute name="units" value="seconds since 1970-01-01 00:00:00 +00:00" type="string" />
 </time>
 <spatial_axis typeOfGrid="lambert" id="x" name="x" type="float">
@@ -99,158 +97,12 @@
     <attribute name="positive" value="up" type="string" />
     <attribute name="units" value="m" type="string" />
 </vertical_axis>
-<vertical_axis id="isotherm_0C_level" name="isotherm_0C_level" grib1_id="4" grib2_id="4" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="description" value="level of 0degreeC isotherm" type="string" />
-    <attribute name="long_name" value="isotherm 0C" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="maximum_wind_level" name="maximum_wind_level" grib1_id="6" grib2_id="6" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="long_name" value="max wind level" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="tropopause" name="tropopause" grib1_id="7" grib2_id="7" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="long_name" value="Tropopause" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="top_of_atmosphere" name="top_of_atmosphere" grib2_id="8" grib1_id="8" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="long_name" value="nominal top of atmosphere" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="isotherm_percK_level" name="isotherm_percK_level" grib1_id="20" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="description" value="level of 1/100K isotherm" type="string" />
-    <attribute name="long_name" value="isotherm %K" type="string" />
-    <attribute name="units" value="1/100 K" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="mean_sea_level" name="mean_sea_level" grib2_id="101" grib1_id="102" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="description" value="mean sea level" type="string" />
-    <attribute name="long_name" value="mean_sea_level" type="string" />
-    <attribute name="positive" value="up" type="string" />
-    <attribute name="units" value="m" type="string" />
-</vertical_axis>
-<vertical_axis id="pressure" name="pressure" grib2_id="100" grib1_id="100" type="float">
-    <!-- Isobaric level -->
-    <attribute name="description" value="pressure" type="string" />
-    <attribute name="long_name" value="pressure" type="string" />
-    <attribute name="standard_name" value="air_pressure" type="string" />
-    <attribute name="positive" value="down" type="string" />
-    <grib1>
-        <attribute name="units" value="hPa" type="string" />
-    </grib1>
-    <grib2>
-        <attribute name="units" value="Pa" type="string" />
-    </grib2>
-</vertical_axis>
-<vertical_axis id="height_above_msl" name="height_above_msl" grib2_id="102" grib1_id="103" type="float">
-    <attribute name="description" value="height above MSL, altitude" type="string" />
-    <attribute name="long_name" value="height" type="string" />
-    <attribute name="positive" value="up" type="string" />
-    <attribute name="units" value="m" type="string" />
-</vertical_axis>
-<vertical_axis id="layer_between_altitudes" name="layer_between_altitudes" grib1_id="104" type="float">
-    <attribute name="description" value="layer between two altitudes" type="string" />
-    <attribute name="long_name" value="layer between two altitudes" type="string" />
-    <attribute name="positive" value="up" type="string" />
-    <attribute name="units" value="100m" type="string" />
-</vertical_axis>
+
 <vertical_axis id="height" name="height" grib2_id="103" grib1_id="105" type="float">
     <attribute name="description" value="height above ground" type="string" />
     <attribute name="long_name" value="height" type="string" />
     <attribute name="positive" value="up" type="string" />
     <attribute name="units" value="m" type="string" />
-</vertical_axis>
-<vertical_axis id="sigma" name="sigma" grib2_id="104" grib1_id="107" type="float">
-    <attribute name="description" value="atmosphere sigma coordinate" type="string" />
-    <attribute name="long_name" value="atmosphere_sigma_coordinate" type="string" />
-    <attribute name="standard_name" value="atmosphere_sigma_coordinate" type="string" />
-    <attribute name="positive" value="down" type="string" />
-</vertical_axis>
-<vertical_axis id="hybrid" name="k" grib2_id="105" grib1_id="109" type="double">
-    <attribute name="standard_name" value="atmosphere_hybrid_sigma_pressure_coordinate" type="string" />
-    <attribute name="formula" value="p(n,k,j,i) = ap(k) + b(k)*ps(n,j,i)" type="string" />
-    <attribute name="formula_terms" value="ap: ap%EXT% b: b%EXT% ps: ps p0: p0%EXT%" type="string" />
-    <attribute name="long_name" value="atmosphere_hybrid_sigma_pressure_coordinate" type="string" />
-    <attribute name="positive" value="down" type="string" />
-    <values mode="hybridSigmaCalc(ap,b,p0)" />
-    <!--  optional values, will otherwise be calculated -->
-    <!-- <values mode="inline">0.01000025677 0.030167302165 0.0506574118 0.071450009935 0.09252333188 0.1138544163 0.13541913675 0.15719222585 0.17914733025 0.2012570937 0.2234932623 0.24582677445 0.2682278651 0.2906662383 0.31311114455 0.3355315966 0.35789645305 0.38017460195 0.40233509685 0.424347324 0.4461811847 0.4678071633 0.489196539 0.5103215403 0.5311554552 0.55167275145 0.5718492055 0.59166201445 0.61108997355 0.6301135343 0.6487148597 0.66687796335 0.6845887315 0.70183494755 0.71860654485 0.73489551425 0.75069577035 0.7660033971 0.78081677885 0.7951363129 0.80896444377 0.82230582149 0.83516716094 0.847557280535 0.859487003145 0.87096914209 0.882018498895 0.892651686215 0.90288721645 0.912745443885 0.92224845265 0.931419910746 0.9402852619265 0.9488715493425 0.9572073044055 0.96532265475235 0.97331471657385 0.981184395 0.98881774 0.996283525</values> -->
-    <additional_axis_variable name="p0" type="double" axis="">
-        <attribute name="units" value="Pa" type="string" />
-        <values>101325</values>
-    </additional_axis_variable>
-    <additional_axis_variable name="ap" type="double" axis="k">
-        <attribute name="units" value="Pa" type="string" />
-        <values mode="extraHalvLevel1" scale_factor="1" />
-        <!--  optional values, will otherwise be retrieved from level2 -->
-        <!--  <values>1000.025677 3016.7302165 5053.90618 7087.0199935 9093.765188 11053.98013 12949.566675 14764.408585 16484.295025 18096.84587 19591.43773 20959.130445 22192.59551 23286.04683 24235.168455 25037.05066 25690.118305 26194.061695 26549.769185 26759.2609 26825.62347 26752.93383 26546.1954 26211.27253 25754.81752 25184.199145 24507.43255 23733.106445 22870.320355 21928.60293 20917.83697 19848.187335 18730.02765 17573.856255 16390.225985 15189.661425 13982.572535 12779.18721 11589.468885 10423.01579 9288.991377 8196.045649 7152.209594 6164.8270535 5240.4653145 4384.825709 3602.6483895 2897.6316215 2272.348645 1728.1508885 1265.082265 881.7835746 575.42419265 341.59793425 174.23244055 65.519475235 12.368657385 0 0 0</values> -->
-    </additional_axis_variable>
-    <additional_axis_variable name="b" type="double" axis="k">
-        <attribute name="units" value="1" type="string" />
-        <values mode="extraHalvLevel2" scale_factor="1" />
-        <!--  optional values, will otherwise be retrieved from ident19 -->
-        <!--  <values>0 0 0.00011835 0.00057981 0.00158568 0.003314615 0.00592347 0.00954814 0.01430438 0.020288635 0.027578885 0.03623547 0.04630191 0.05780577 0.07075946 0.08516109 0.10099527 0.118233985 0.136837405 0.156754715 0.17792495 0.200277825 0.223734585 0.248208815 0.27360728 0.29983076 0.32677488 0.35433095 0.38238677 0.410827505 0.43953649 0.46839609 0.497288455 0.526096385 0.554704285 0.5829989 0.610870045 0.638211525 0.66492209 0.690906155 0.71607453 0.740345365 0.763645065 0.78590901 0.80708235 0.827120885 0.845992015 0.86367537 0.88016373 0.895463935 0.90959763 0.922602075 0.93453102 0.94545557 0.95546498 0.96466746 0.97319103 0.981184395 0.98881774 0.996283525</values> -->
-    </additional_axis_variable>
-</vertical_axis>
-<vertical_axis id="depth" name="depth" grib2_id="106" type="short">
-    <attribute name="description" value="depth below land surface" type="string" />
-    <attribute name="long_name" value="depth" type="string" />
-    <attribute name="positive" value="down" type="string" />
-    <attribute name="standard_name" value="depth" type="string" />
-    <grib1>
-        <attribute name="units" value="cm" type="string" />
-    </grib1>
-    <grib2>
-        <attribute name="units" value="m" type="string" />
-    </grib2>
-</vertical_axis>
-<vertical_axis id="specified_pressure_difference" name="specified_pressure_difference" grib2_id="108" type="float">
-    <attribute name="description" value="Level at specified pressure difference from ground to level" type="string" />
-    <attribute name="long_name" value="specified pressure difference from ground" type="string" />
-    <attribute name="standard_name" value="air_pressure" type="string" />
-    <attribute name="positive" value="up" type="string" />
-    <grib2>
-        <attribute name="units" value="Pa" type="string" />
-    </grib2>
-</vertical_axis>
-<vertical_axis id="potential_vorticity_surface" name="potential_vorticity_surface" grib2_id="109" type="float">
-    <attribute name="description" value="Potential vorticity surface" type="string" />
-    <attribute name="long_name" value="potential vorticity surface" type="string" />
-    <attribute name="standard_name" value="ertel_potential_vorticity" type="string" />
-    <attribute name="positive" value="up" type="string" />
-    <grib2>
-        <attribute name="units" value="K m^2 kg^-1 s^-1" type="string" />
-    </grib2>
-</vertical_axis>
-<vertical_axis id="depth_between_layers" name="depth_between_layers" grib1_id="112" type="short">
-<!-- TODO, the 2 layers are not read correctly yet. I need a special function to extract the 2 levels from one grib-field
-           like in  hybridSigma -->
-    <attribute name="description" value="depth between layers below land surface" type="string" />
-    <attribute name="long_name" value="depth between layes" type="string" />
-    <attribute name="positive" value="down" type="string" />
-    <attribute name="standard_name" value="depth" type="string" />
-    <attribute name="units" value="cm" type="string" />
-</vertical_axis>
-<vertical_axis id="theta" name="theta" grib2_id="107" grib1_id="113" type="float">
-    <attribute name="description" value="isentropic layer" type="string" />
-    <attribute name="units" value="K" type="string" />
-</vertical_axis>
-<vertical_axis id="depth_below_sea" name="depth_below_sea" grib2_id="160" grib1_id="160" type="short">
-    <attribute name="description" value="depth below sea surface" type="string" />
-    <attribute name="long_name" value="depth_below_sea" type="string" />
-    <attribute name="positive" value="down" type="string" />
-    <attribute name="standard_name" value="depth" type="string" />
-    <attribute name="units" value="m" type="string" />
-</vertical_axis>
-
-<vertical_axis id="harmoniUnknown117" name="harmoniUnknown117" grib1_id="117" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="positive" value="up" type="string" />
 </vertical_axis>
 
 <vertical_axis id="adiabatic_condensation_level" name="adiabatic_condensation_level" grib1_id="5" type="short">
@@ -259,180 +111,15 @@
     <attribute name="positive" value="up" type="string" />
 </vertical_axis>
 
-<vertical_axis id="harmoniUnknown10" name="harmoniUnknown10" grib1_id="10" type="short">
-    <attribute name="_FillValue" value="-32767" type="short" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-
-
 <vertical_axis id="total_atmosphere" name="total_atmosphere" grib1_id="200" type="short">
     <attribute name="_FillValue" value="-32767" type="short" />
     <attribute name="long_name" value="total atmosphere as single layer" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_200" name="local_vertical_level_200" grib2_id="200" type="float">
-    <attribute name="description" value="vertical level 200, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 200" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="entire_ocean" name="entire_ocean" grib2_id="201" grib1_id="201" type="float">
-    <attribute name="long_name" value="entire ocean as single layer" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_204" name="local_vertical_level_204" grib2_id="204" type="float">
-    <attribute name="description" value="vertical level 204, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 204" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_211" name="local_vertical_level_211" grib2_id="211" type="float">
-    <attribute name="description" value="vertical level 211, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 211" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_212" name="local_vertical_level_212" grib2_id="212" type="float">
-    <attribute name="description" value="vertical level 212, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 212" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_213" name="local_vertical_level_213" grib2_id="213" type="float">
-    <attribute name="description" value="vertical level 213, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 213" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_214" name="local_vertical_level_214" grib2_id="214" type="float">
-    <attribute name="description" value="vertical level 214, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 214" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_222" name="local_vertical_level_222" grib2_id="222" type="float">
-    <attribute name="description" value="vertical level 222, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 222" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_223" name="local_vertical_level_223" grib2_id="223" type="float">
-    <attribute name="description" value="vertical level 223, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 223" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_224" name="local_vertical_level_224" grib2_id="224" type="float">
-    <attribute name="description" value="vertical level 224, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 224" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_232" name="local_vertical_level_232" grib2_id="232" type="float">
-    <attribute name="description" value="vertical level 232, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 232" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_233" name="local_vertical_level_233" grib2_id="233" type="float">
-    <attribute name="description" value="vertical level 233, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 233" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_234" name="local_vertical_level_234" grib2_id="234" type="float">
-    <attribute name="description" value="vertical level 234, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 234" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_242" name="local_vertical_level_242" grib2_id="242" type="float">
-    <attribute name="description" value="vertical level 242, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 242" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_243" name="local_vertical_level_243" grib2_id="243" type="float">
-    <attribute name="description" value="vertical level 243, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 243" type="string" />
-    <attribute name="positive" value="up" type="string" />
-</vertical_axis>
-<vertical_axis id="local_vertical_level_244" name="local_vertical_level_244" grib2_id="244" type="float">
-    <attribute name="description" value="vertical level 244, defined locally, ask center" type="string" />
-    <attribute name="long_name" value="unknown vertical level 244" type="string" />
     <attribute name="positive" value="up" type="string" />
 </vertical_axis>
 
 </axes>
 
 <variables>
-      <!-- Pressure () -->
-      <parameter name="air_pressure_at_sea_level" type="float">
-          <grib1 indicatorOfParameter="151" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="1" levelNo="0"/>
-          <grib2 discipline="0" parameterCategory="3" parameterNumber="1" typeOfLevel="1"/>
-          <attribute name="long_name" value="Mean Sea Level Pressure (MSLP)" type="string"/>
-          <attribute name="standard_name" value="air_pressure_at_sea_level" type="string"/>
-          <attribute name="units" value="Pa" type="string"/>
-      </parameter>
-      <parameter name="surface_air_pressure" type="float">
-          <grib1 indicatorOfParameter="134" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="1" levelNo="0"/>
-          <grib2 discipline="0" parameterCategory="3" parameterNumber="0" typeOfLevel="1"/>
-<attribute name="long_name" value="Surface air pressure" type="string"/>
-          <attribute name="standard_name" value="surface_air_pressure" type="string"/>
-          <attribute name="units" value="Pa" type="string"/>
-      </parameter>
-      <!-- logarithmic surface_air_pressure -->
-      <parameter name="surface_air_pressure" type="float">
-          <grib2 discipline="0" parameterCategory="3" parameterNumber="25" typeOfLevel="105"/>
-          <attribute name="long_name" value="Logarithmic surface air pressure (lnsp)" type="string"/>
-          <attribute name="standard_name" value="surface_air_pressure" type="string"/>
-          <attribute name="units" value="1 ln(re 1Pa)" type="string"/>
-      </parameter>
-
-    <parameter name="geopotential_height_pl" type="float">
-        <!-- multi-id for grib1 and grib2 -->
-        <grib1 indicatorOfParameter="156" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" timeRangeIndicator="0"/>
-        <!-- wmo -->
-        <grib1 indicatorOfParameter="7" gribTablesVersionNo="1"/>
-        <grib1 indicatorOfParameter="7" gribTablesVersionNo="2"/>
-        <grib1 indicatorOfParameter="7" gribTablesVersionNo="3"/>
-        <grib2 discipline="0" parameterCategory="3" parameterNumber="5" typeOfLevel="100"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="long_name" value="geopotential_height" type="string" />
-        <attribute name="standard_name" value="geopotential_height" type="string" />
-        <attribute name="units" value="m" type="string" />
-    </parameter>
-    <parameter name="geopotential_pl" type="float">
-        <grib1 indicatorOfParameter="156" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="100"/>
-        <grib2 discipline="0" parameterCategory="3" parameterNumber="4" typeOfLevel="105"/>
-        <attribute name="long_name" value="Geopotential pressure levels" type="string"/>
-        <attribute name="standard_name" value="geopotential" type="string"/>
-        <attribute name="units" value="m^2/s^2" type="string"/>
-    </parameter>
-    <parameter name="geopotential_ml" type="float">
-        <grib1 indicatorOfParameter="129" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="109"/>
-        <grib2 discipline="0" parameterCategory="3" parameterNumber="4" typeOfLevel="100"/>
-        <attribute name="long_name" value="Geopotential model levels" type="string" />
-        <attribute name="standard_name" value="geopotential" type="string" />
-        <attribute name="units" value="m^2/s^2" type="string" />
-    </parameter>
-    <parameter name="surface_geopotential" type="float" constantTime="true">
-        <grib1 indicatorOfParameter="129" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="1"/>
-        <grib2 discipline="0" parameterCategory="3" parameterNumber="4" typeOfLevel="103"/>
-        <attribute name="long_name" value="Surface geopotential (fis)" type="string" />
-        <attribute name="standard_name" value="surface_geopotential" type="string" />
-        <attribute name="units" value="m^2/s^2" type="string" />
-    </parameter>
-    <parameter name="surface_altitude" type="float">
-        <grib2 discipline="0" parameterCategory="3" parameterNumber="5" typeOfLevel="1"/>
-        <grib1 indicatorOfParameter="7" gribTablesVersionNo="253" identificationOfOriginatingGeneratingCentre="233" typeOfLevel="105" levelNo="0"/>
-        <attribute name="long_name" value="Orography (ZS)" type="string" />
-        <attribute name="standard_name" value="surface_altitude" type="string" />
-        <attribute name="units" value="m" type="string" />
-    </parameter>
-
-    <parameter name="cloud_cover" type="float">
-        <!-- multi-id for grib1 and grib2 -->
-        <!-- high clouds -->
-        <grib1 indicatorOfParameter="188" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <!-- medium clouds, sigma level-->
-        <grib1 typeOfLevel="107" indicatorOfParameter="187" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <!-- below examples allow omission of identificationOfOriginatingGeneratingCentre or gribTablesVersionNo -->
-        <!-- low clouds -->
-        <grib1 indicatorOfParameter="186" gribTablesVersionNo="128" />
-        <!-- fog -->
-        <grib1 indicatorOfParameter="248" identificationOfOriginatingGeneratingCentre="98"/>
-        <!--  <grib2 discipline="" parameterCategory="" parameterNumber=""/> -->
-        <attribute name="long_name" value="cloud coverage" type="string" />
-        <attribute name="units" value="%" type="string" />
-    </parameter>
     <parameter name="total_precipitation" type="float">
         <grib1 indicatorOfParameter="61" gribTablesVersionNo="3"/>
         <grib2 discipline="0" parameterCategory="1" parameterNumber="52" />
@@ -440,38 +127,11 @@
         <attribute name="units" value="kg m^-2" type="string" />
     </parameter>
 
-<!-- from metcoop -->
-    <parameter name="x_wind_10m" type="float">
-        <grib1 indicatorOfParameter="33" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="x_wind" type="string" />
-        <attribute name="units" value="m s^-1" type="string" />
-    </parameter>
-    <parameter name="y_wind_10m" type="float">
-        <grib1 indicatorOfParameter="34" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="y_wind" type="string" />
-        <attribute name="units" value="m s^-1" type="string" />
-    </parameter>
     <parameter name="x_wind_10m" type="float">
         <grib1 indicatorOfParameter="33" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="100"/>
         <grib2 discipline="0" parameterCategory="2" parameterNumber="2" typeOfLevel="103" level="10"/>
         <attribute name="standard_name" value="x_wind" type="string" />
         <attribute name="units" value="m s^-1" type="string" />
-    </parameter>
-    <parameter name="x_wind_pl" type="float">
-        <grib2 discipline="0" parameterCategory="2" parameterNumber="2" typeOfLevel="100"/>
-        <!-- <grib1 indicatorOfParameter="33" gribTablesVersionNo="253" identificationOfOriginatingGeneratingCentre="233" typeOfLevel="109"/> -->
-        <attribute name="long_name" value="Zonal wind model levels" type="string" />
-        <attribute name="standard_name" value="x_wind" type="string" />
-        <attribute name="units" value="m/s" type="string" />
-        <spatial_vector direction="x,longitude" counterpart="y_wind_ml" />
-    </parameter>
-    <parameter name="x_wind_ml" type="float">
-        <grib2 discipline="0" parameterCategory="2" parameterNumber="2" typeOfLevel="105"/>
-        <!-- <grib1 indicatorOfParameter="33" gribTablesVersionNo="253" identificationOfOriginatingGeneratingCentre="233" typeOfLevel="109"/> -->
-        <attribute name="long_name" value="Zonal wind model levels" type="string" />
-        <attribute name="standard_name" value="x_wind" type="string" />
-        <attribute name="units" value="m/s" type="string" />
-        <spatial_vector direction="x,longitude" counterpart="y_wind_ml" />
     </parameter>
 
     <parameter name="y_wind_10m" type="float">
@@ -480,191 +140,17 @@
         <attribute name="standard_name" value="y_wind" type="string" />
         <attribute name="units" value="m s^-1" type="string" />
     </parameter>
-    <parameter name="y_wind_pl" type="float">
-        <grib2 discipline="0" parameterCategory="2" parameterNumber="3" typeOfLevel="100"/>
-        <grib1 indicatorOfParameter="132" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="100"/>
-        <attribute name="long_name" value="Meridional wind pressure levels" type="string"/>
-        <attribute name="standard_name" value="y_wind" type="string"/>
-        <attribute name="units" value="m/s" type="string"/>
-        <spatial_vector direction="y,latitude" counterpart="x_wind_pl"/>
-    </parameter>
-    <parameter name="y_wind_ml" type="float">
-        <grib2 discipline="0" parameterCategory="2" parameterNumber="3" typeOfLevel="105"/>
-<!--         <grib1 indicatorOfParameter="34" gribTablesVersionNo="253" identificationOfOriginatingGeneratingCentre="233" typeOfLevel="105"/>
- -->        <attribute name="long_name" value="Meridional wind model levels" type="string" />
-        <attribute name="standard_name" value="y_wind" type="string" />
-        <attribute name="units" value="m/s" type="string" />
-        <spatial_vector direction="y,latitude" counterpart="x_wind_ml" />
-    </parameter>
-      <!-- skin temperature -->
-      <parameter name="surface_temperature" type="float">
-        <grib2 discipline="0" parameterCategory="0" parameterNumber="0" typeOfLevel="1" level="0"/>
-        <grib1 indicatorOfParameter="235" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="1" levelNo="0"/>
-        <attribute name="long_name" value="Surface (skin) temperature (SKT)" type="string"/>
-        <attribute name="standard_name" value="surface_temperature" type="string"/>
-        <attribute name="units" value="K" type="string"/>
-      </parameter>
     <parameter name="air_temperature_2m" type="float">
         <grib2 discipline="0" parameterCategory="0" parameterNumber="0" typeOfLevel="103" level="2"/>
         <grib1 indicatorOfParameter="11" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105" levelNo="2"/>
         <attribute name="standard_name" value="air_temperature" type="string" />
         <attribute name="units" value="K" type="string" />
     </parameter>
-    <parameter name="air_temperature_pl" type="float">
-        <grib2 discipline="0" parameterCategory="0" parameterNumber="0" typeOfLevel="100"/>
-        <attribute name="standard_name" value="air_temperature" type="string" />
-        <attribute name="units" value="K" type="string" />
-    </parameter>
-    <parameter name="tk" type="float">
-        <grib1 indicatorOfParameter="11" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="100"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="air_temperature" type="string" />
-        <attribute name="units" value="K" type="string" />
-    </parameter>
-      <!-- 2m dew point temperature -->
-      <parameter name="dew_point_temperature_2m" type="float">
-        <grib1 indicatorOfParameter="168" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98" typeOfLevel="1" levelNo="0"/>
-        <grib2 discipline="0" parameterCategory="0" parameterNumber="6" typeOfLevel="103" level="2"/>
-        <attribute name="standard_name" value="dew_point_temperature" type="string"/>
-        <attribute name="units" value="K" type="string"/>
-      </parameter>
-
-    <parameter name="fi" type="float" constantTime="true">
-        <grib1 indicatorOfParameter="6" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="100"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="geopotential_height" type="string" />
-        <attribute name="units" value="m" type="string" />
-    </parameter>
-    <parameter name="fis" type="float">
-        <grib1 indicatorOfParameter="6" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="geopotential_height" type="string" />
-        <attribute name="units" value="m" type="string" />
-    </parameter>
-    <parameter name="q" type="float">
-        <grib1 indicatorOfParameter="51" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="100"/>
-        <attribute name="standard_name" value="specific_humidity" type="string" />
-        <attribute name="units" value="1" type="string" />
-    </parameter>
-    <parameter name="omega_ml" type="float">
-        <grib1 indicatorOfParameter="40" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="100"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standname_name" value="omega" type="string" />
-        <attribute name="units" value="Pa/s" type="string" />
-    </parameter>
     <parameter name="relative_humidity_2m" type="float">
         <grib2 discipline="0" parameterCategory="1" parameterNumber="1" typeOfLevel="103" level="2"/>
         <grib1 indicatorOfParameter="52" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
         <attribute name="standard_name" value="relative_humidity" type="string" />
         <attribute name="units" value="1" type="string" />
-    </parameter>
-    <parameter name="relative_humidity_pl" type="float">
-        <grib2 discipline="0" parameterCategory="1" parameterNumber="1" typeOfLevel="100"/>
-        <grib1 indicatorOfParameter="52" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="100"/>
-        <attribute name="standard_name" value="relative_humidity" type="string" />
-        <attribute name="units" value="1" type="string" />
-    </parameter>
-    <parameter name="visibility_in_air" type="float">
-        <grib2 discipline="0" parameterCategory="19" parameterNumber="0" typeOfLevel="1"/>
-        <attribute name="standard_name" value="relative_humidity" type="string" />
-        <attribute name="units" value="1" type="string" />
-    </parameter>
-    <parameter name="tcc" type="float">
-        <grib1 indicatorOfParameter="71" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="cloud_area_fraction" type="string" />
-        <attribute name="units" value="%" type="string" />
-    </parameter>
-    <parameter name="lcc" type="float">
-        <grib1 indicatorOfParameter="73" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="low_type_cloud_area_fraction" type="string" />
-        <attribute name="units" value="%" type="string" />
-    </parameter>
-    <parameter name="mcc" type="float">
-        <grib1 indicatorOfParameter="74" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="medium_type_cloud_area_fraction" type="string" />
-        <attribute name="units" value="%" type="string" />
-    </parameter>
-    <parameter name="hcc" type="float">
-        <grib1 indicatorOfParameter="75" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="high_type_cloud_area_fraction" type="string" />
-        <attribute name="units" value="%" type="string" />
-    </parameter>
-    <parameter name="lwe_thickness_of_stratiform_precipitation_amount" type="float">
-        <grib1 indicatorOfParameter="62" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="lwe_thickness_of_stratiform_precipitation_amount" type="string" />
-        <attribute name="units" value="m" type="string" />
-    </parameter>
-    <parameter name="lwe_thickness_of_convective_precipitation_amount" type="float">
-        <grib1 indicatorOfParameter="63" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="lwe_thickness_of_convective_precipitation_amount" type="string" />
-        <attribute name="units" value="m" type="string" />
-    </parameter>
-    <parameter name="air_pressure_at_sea_level" type="float">
-        <grib1 indicatorOfParameter="1" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="103"/>
-        <attribute name="standard_name" value="air_pressure_at_sea_level" type="string" />
-        <attribute name="units" value="Pa" type="string" />
-    </parameter>
-    <parameter name="surface_air_pressure" type="float">
-        <grib1 indicatorOfParameter="1" gribTablesVersionNo="1" identificationOfOriginatingGeneratingCentre="96" typeOfLevel="105"/>
-        <attribute name="standard_name" value="surface_air_pressure" type="string" />
-        <attribute name="units" value="Pa" type="string" />
-    </parameter>
-
-<!-- from MEE ensembles (ec) -->
-    <parameter name="geopotential" type="float" constantTime="true">
-        <grib1 indicatorOfParameter="129" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="long_name" value="geopotential" type="string" />
-        <attribute name="standard_name" value="geopotential" type="string" />
-        <attribute name="units" value="m2/s2" type="string" />
-    </parameter>
-    <parameter name="lwe_thickness_of_percipitation_amount" type="float">
-        <grib1 indicatorOfParameter="228" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="lwe_thickness_of_percipitation_amount" type="string" />
-        <attribute name="units" value="kg/m2" type="string" />
-    </parameter>
-    <parameter name="lwe_thickness_of_snowfall_amount" type="float">
-        <grib1 indicatorOfParameter="144" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="lwe_thickness_of_snowfall_amount" type="string" />
-        <attribute name="units" value="kg/m2" type="string" />
-    </parameter>
-    <parameter name="cloud_area_fraction" type="short">
-        <grib1 indicatorOfParameter="164" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="-32767" type="short" />
-        <attribute name="scale_factor" value="0.0001" type="float" />
-        <attribute name="standard_name" value="cloud_area_fraction" type="string" />
-        <attribute name="units" value="1" type="string" />
-    </parameter>
-    <parameter name="air_temperature" type="float">
-        <grib1 indicatorOfParameter="130" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="air_temperature" type="string" />
-        <attribute name="units" value="K" type="string" />
-    </parameter>
-    <parameter name="dewpoint_2m" type="float">
-        <grib1 indicatorOfParameter="168" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="units" value="K" type="string" />
-    </parameter>
-    <parameter name="air_temperature_2m" type="float">
-        <grib1 indicatorOfParameter="167" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="air_temperature" type="string" />
-        <attribute name="units" value="K" type="string" />
-    </parameter>
-    <parameter name="max_air_temperature_2m" type="float">
-        <grib1 indicatorOfParameter="121" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="air_temperature" type="string" />
-        <attribute name="units" value="K" type="string" />
-    </parameter>
-    <parameter name="min_air_temperature_2m" type="float">
-        <grib1 indicatorOfParameter="122" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="air_temperature" type="string" />
-        <attribute name="units" value="K" type="string" />
     </parameter>
     <parameter name="x_wind_10m" type="float">
         <grib1 indicatorOfParameter="165" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98">
@@ -680,45 +166,7 @@
         <attribute name="standard_name" value="y_wind" type="string" />
         <attribute name="units" value="m/s" type="string" />
     </parameter>
-    <parameter name="max_wind_speed_of_gust_10m" type="float">
-        <grib1 indicatorOfParameter="123" gribTablesVersionNo="128" identificationOfOriginatingGeneratingCentre="98"/>
-        <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-        <attribute name="standard_name" value="max_wind_speed_of_gust" type="string" />
-        <attribute name="units" value="m/s" type="string" />
-    </parameter>
-
-    <!-- wave parameters -->
-    <parameter name="significant_wave_height" type="float">
-      <grib1 indicatorOfParameter="229" gribTablesVersionNo="140" />
-      <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-      <attribute name="units" value="m" type="string"/>
-      <attribute name="standard_name" value="sea_surface_wave_significant_height" type="string"/>
-    </parameter>
-    <parameter name="wave_direction" type="float">
-      <grib1 indicatorOfParameter="230" gribTablesVersionNo="140"/>
-      <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-      <attribute name="units" value="degree" type="string"/>
-      <attribute name="standard_name" value="sea_surface_wave_to_direction" type="string"/>
-    </parameter>
-    <parameter name="peak_wave_period"  type="float">
-      <grib1 indicatorOfParameter="231" gribTablesVersionNo="140"/>
-      <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-      <attribute name="long_name" value="sea_surface_wave_peak_period" type="string"/>
-      <attribute name="units" value="s" type="string"/>
-    </parameter>
-    <parameter  name="mean_wave_period"  type="float">
-      <grib1 indicatorOfParameter="232" gribTablesVersionNo="140"/>
-      <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
-      <attribute name="units" value="s" type="string"/>
-      <attribute name="standard_name" value="sea_surface_wave_mean_period_from_variance_spectral_density_first_frequency_moment" type="string"/>
-      <attribute name="long_name" value="sea_surface_wave_significant_period" type="string"/>
-    </parameter>
-    <parameter name="cdww"  type="float">
-      <grib1 indicatorOfParameter="233" gribTablesVersionNo="140"/>
-      <attribute name="units" value="" type="string"/>
-      <attribute name="long_name" value="sea_surface_wave_drag_coefficient" type="string"/>
-    </parameter>
-    <parameter name="wind_speed_10m"  type="float">
+    <parameter name="wind_speed_10m" type="float">
       <grib1 indicatorOfParameter="245" gribTablesVersionNo="140"/>
       <attribute name="_FillValue" value="9.9692099683868690e+36f" type="float" />
       <attribute name="units" value="m/s" type="string"/>

--- a/python/day_archiver.py
+++ b/python/day_archiver.py
@@ -70,8 +70,11 @@ def accumulate_variables(input_netcdf_path, output_netcdf_path, forecast_drop=Tr
 
     ds["mean_wind_speed_10m"] = ds["wind_speed_10m"].mean(dim="time")
 
+    # Converts W/m2 to MJ/m2
+    ds["daily_surface_net_downward_shortwave_flux"] = ds["surface_net_downward_shortwave_flux"].sum(dim="time") * 0.0036
+    ds["daily_surface_net_downward_shortwave_flux"].attrs["units"] = "MJ/m^2"
     ds = ds.drop_vars(["air_temperature_2m", "relative_humidity_2m", "hourly_precipitation",
-                       "wind_speed_10m"])
+                       "wind_speed_10m", "surface_net_downward_shortwave_flux"])
     if forecast_drop is True:
         ds = ds.drop_vars(["forecast_reference_time"])
     ds.isel(time=[0]).to_netcdf(output_netcdf_path)

--- a/python/forecaster.py
+++ b/python/forecaster.py
@@ -113,7 +113,7 @@ def forecaster(inpath, outpath):
         ds["air_temperature_2m"].values = ds["air_temperature_2m"].values - 273.15
         ds["air_temperature_2m"].attrs["units"] = "degC"
     ds["wind_speed_10m"] = np.sqrt(ds["x_wind_10m"]**2 + ds["y_wind_10m"]**2)
-    ds = ds.drop_vars[["ASOB_S"]]
+    ds = ds.drop_vars(["ASOB_S"])
     ds.to_netcdf(outpath)
     ds.close()
 

--- a/python/forecaster.py
+++ b/python/forecaster.py
@@ -98,11 +98,12 @@ def forecaster(inpath, outpath):
     Converts to wind speed, calculates hourly precipitation,
     converts temperature to Celsius if temperature is in Kelvin
     converts ASOB_S [W/m2] (Average Net short-wave radiation flux at surface)
-    to Hourly Net short-wave radiation (Which will be computed to daily values)
+    to Hourly Net short-wave radiation [W/m2] (Which will be computed to daily values)
     """
     ds = xr.open_dataset(inpath)
     surface_rad = "surface_net_downward_shortwave_flux"
     ds[surface_rad] = ds["ASOB_S"]
+    ds[surface_rad].attrs["units"] = "W/m^2"
     for time in range(len(ds.time.values)):
         ds[surface_rad].values[time, :, :, :] *= time
     ds[surface_rad] = ds[surface_rad].diff(dim="time")
@@ -112,6 +113,7 @@ def forecaster(inpath, outpath):
         ds["air_temperature_2m"].values = ds["air_temperature_2m"].values - 273.15
         ds["air_temperature_2m"].attrs["units"] = "degC"
     ds["wind_speed_10m"] = np.sqrt(ds["x_wind_10m"]**2 + ds["y_wind_10m"]**2)
+    ds = ds.drop_vars[["ASOB_S"]]
     ds.to_netcdf(outpath)
     ds.close()
 

--- a/python/poller_and_downloader.py
+++ b/python/poller_and_downloader.py
@@ -34,7 +34,7 @@ class Poller():
     def __init__(self, ftp_username, ftp_password, ftp_account, latest_reftime=None,
                  ftp_url="opendata.dwd.de", base_ftp_link="/weather/nwp/icon-eu/grib",
                  variable_base="icon-eu_europe_regular-lat-lon_single-level_",
-                 variable_list=("t_2m", "relhum_2m", "v_10m", "u_10m", "tot_prec"),
+                 variable_list=("t_2m", "relhum_2m", "v_10m", "u_10m", "tot_prec", "asob_s"),
                  main_cycles=("00", "06", "12", "18"), max_leadtime="_078_"):
         """
         Initiates an object with ftp credentials and ftp url.


### PR DESCRIPTION
Adds surface_net_downward_shortwave_flux (units W/m²) and daily_surface_net_downward_shortwave_flux (units MJ/m²)
Also removes lots of met.no specific variable-definitions from the cdmGribReaderConfig (And adds the definition for ASOB_S from DWD)