### PR TITLE
Tolerate missing all xxxxxxxxxx.nc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.venv
 .vscode/
 .project
 .pydevproject

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -3,3 +3,4 @@
 /euroweatherdata
 # Ignore log-files
 *.log
+.venv/*

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -3,4 +3,4 @@
 /euroweatherdata
 # Ignore log-files
 *.log
-.venv/*
+.venv/

--- a/python/daily_archiver.py
+++ b/python/daily_archiver.py
@@ -38,11 +38,14 @@ main_cycles = CONFIG.get("main_cycles")
 ARCHIVE_PATH = CONFIG.get("archive_path")
 
 ds = archive_day(reftime, day_before)
-ds.isel(time=range(1, 25)).to_netcdf(f"{ARCHIVE_PATH}daily_archive_{reftime}.nc")
+logger.debug("Creating the NetCDF file")
+ds.isel(time=range(1, 25)).load().to_netcdf(f"{ARCHIVE_PATH}daily_archive_{reftime}.nc")
 ds.close()
-
+logger.debug("Done creating the NetCDF file")
+logger.debug("Accumulating variables")
 accumulate_variables(f"{ARCHIVE_PATH}daily_archive_{reftime}.nc", f"{ARCHIVE_PATH}daily_accumulated_{reftime}.nc")
-
+logger.debug("Done accumulating variables")
+logger.debug("Appending to year file")
 # Append newly created accumulated to the year file if it exists:
 # If it does not exist, rename daily_accumulated_REFTIME.nc to YEAR.nc (only happens on 1st of january)
 if os.path.isfile(f"{ARCHIVE_PATH}{YEAR}.nc"):
@@ -54,6 +57,9 @@ if os.path.isfile(f"{ARCHIVE_PATH}{YEAR}.nc"):
 else:
     ds = xr.open_mfdataset([f"{ARCHIVE_PATH}daily_accumulated_{reftime}.nc"], lock=False)
 
+logger.debug("Writing to year file")
+
 ds.to_netcdf(f"{ARCHIVE_PATH}{YEAR}.nc_tmp")
 ds.close()
+logger.debug("Done appending to year file")
 os.rename(f"{ARCHIVE_PATH}{YEAR}.nc_tmp", f"{ARCHIVE_PATH}{YEAR}.nc")

--- a/python/daily_archiver.py
+++ b/python/daily_archiver.py
@@ -38,14 +38,10 @@ main_cycles = CONFIG.get("main_cycles")
 ARCHIVE_PATH = CONFIG.get("archive_path")
 
 ds = archive_day(reftime, day_before)
-logger.debug("Creating the NetCDF file")
 ds.isel(time=range(1, 25)).load().to_netcdf(f"{ARCHIVE_PATH}daily_archive_{reftime}.nc")
 ds.close()
-logger.debug("Done creating the NetCDF file")
-logger.debug("Accumulating variables")
 accumulate_variables(f"{ARCHIVE_PATH}daily_archive_{reftime}.nc", f"{ARCHIVE_PATH}daily_accumulated_{reftime}.nc")
-logger.debug("Done accumulating variables")
-logger.debug("Appending to year file")
+
 # Append newly created accumulated to the year file if it exists:
 # If it does not exist, rename daily_accumulated_REFTIME.nc to YEAR.nc (only happens on 1st of january)
 if os.path.isfile(f"{ARCHIVE_PATH}{YEAR}.nc"):
@@ -57,9 +53,6 @@ if os.path.isfile(f"{ARCHIVE_PATH}{YEAR}.nc"):
 else:
     ds = xr.open_mfdataset([f"{ARCHIVE_PATH}daily_accumulated_{reftime}.nc"], lock=False)
 
-logger.debug("Writing to year file")
-
 ds.to_netcdf(f"{ARCHIVE_PATH}{YEAR}.nc_tmp")
 ds.close()
-logger.debug("Done appending to year file")
 os.rename(f"{ARCHIVE_PATH}{YEAR}.nc_tmp", f"{ARCHIVE_PATH}{YEAR}.nc")

--- a/python/day_archiver.py
+++ b/python/day_archiver.py
@@ -89,13 +89,38 @@ def archive_day(reftime, day_before):
     yesterday = f"all{day_before}{main_cycles[-1]}.nc"
     ds_list = []
     not_first = False
+    """
     for cycle in main_cycles:
         today_i = f"all{reftime}{cycle}.nc"
-        if not_first:
-            ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1)).drop_vars("forecast_reference_time"))
+        if os.path.isfile(ALL_PATH+today_i):
+            if not_first:
+                ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1)).drop_vars("forecast_reference_time"))
+            else:
+                ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1)))
+                not_first = True
         else:
-            ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1)))
-            not_first = True
+            logger.warning(f"File {ALL_PATH+today_i} does not exist, skipping this timestep when archiving {reftime}")
+"""
+    missing_cycles = 0
+    for cycle in reversed(main_cycles):
+        
+        today_i = f"all{reftime}{cycle}.nc"
+        logger.debug(today_i)
+        logger.debug(not_first)
+        logger.debug(missing_cycles)
+        logger.debug(range(1, cycle_nr+1 + missing_cycles))
+        if os.path.isfile(ALL_PATH+today_i):
+            if not_first:
+                ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1 + missing_cycles)).drop_vars("forecast_reference_time"))
+            else:
+                ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1 + missing_cycles)))
+                not_first = True
+            missing_cycles = 0
+        else:
+            logger.warning(f"File {ALL_PATH+today_i} does not exist, skipping this timestep when archiving {reftime}")
+            missing_cycles = 6
+
+    ds_list.reverse()
 
     ds = xr.open_dataset(ALL_PATH+yesterday).isel(time=[cycle_nr-1, cycle_nr]).drop_vars("forecast_reference_time")
 

--- a/python/day_archiver.py
+++ b/python/day_archiver.py
@@ -89,19 +89,8 @@ def archive_day(reftime, day_before):
     yesterday = f"all{day_before}{main_cycles[-1]}.nc"
     ds_list = []
     not_first = False
-    """
-    for cycle in main_cycles:
-        today_i = f"all{reftime}{cycle}.nc"
-        if os.path.isfile(ALL_PATH+today_i):
-            if not_first:
-                ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1)).drop_vars("forecast_reference_time"))
-            else:
-                ds_list.append(xr.open_dataset(ALL_PATH+today_i).isel(time=range(1, cycle_nr+1)))
-                not_first = True
-        else:
-            logger.warning(f"File {ALL_PATH+today_i} does not exist, skipping this timestep when archiving {reftime}")
-"""
     missing_cycles = 0
+    # Going in the reversed order because we need to add 6 hours from the previous cycle if a cycle is missing
     for cycle in reversed(main_cycles):
         
         today_i = f"all{reftime}{cycle}.nc"
@@ -120,6 +109,7 @@ def archive_day(reftime, day_before):
             logger.warning(f"File {ALL_PATH+today_i} does not exist, skipping this timestep when archiving {reftime}")
             missing_cycles = 6
 
+    # Reverse the list to have it in chronological order
     ds_list.reverse()
 
     ds = xr.open_dataset(ALL_PATH+yesterday).isel(time=[cycle_nr-1, cycle_nr]).drop_vars("forecast_reference_time")


### PR DESCRIPTION
This change lets the da(il)y_archiver handle that DWD had a hiccup when creating a fileset. It tolerates one missing main run (either 00, 06, 12, 18)